### PR TITLE
Remove unnecessary label in select filter.

### DIFF
--- a/jquery.dataTables.columnFilter.js
+++ b/jquery.dataTables.columnFilter.js
@@ -334,7 +334,7 @@
                 currentFilter = oSelected;
 
             var selectId = "select" + sLabel.split(" ").join('');
-            var r = '<select id="' + selectId + '" class="search_init select_filter form-control" rel="' + i + '"><option value="" class="search_init"> Filtrar ' + sLabel + '</option>';
+            var r = '<select id="' + selectId + '" class="search_init select_filter form-control" rel="' + i + '"><option value="" class="search_init">' + sLabel + '</option>';
             if (bMultiselect) {
                 r = '<select id="' + selectId + '" class="search_init select_filter form-control" rel="' + i + '" multiple="multiple">';
             }


### PR DESCRIPTION
Looks like this "Filtrar" word was never there in the original library. Would be good to get rid of it.
